### PR TITLE
Add read replica option to some accessor API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+submissions_test_db
 
 # Translations
 *.mo

--- a/manage.py
+++ b/manage.py
@@ -7,5 +7,8 @@ if __name__ == "__main__":
     if os.environ.get('DJANGO_SETTINGS_MODULE') is None:
         os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
+    if 'test' in sys.argv[:3]:
+        sys.argv.append('--noinput')
+
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)

--- a/settings.py
+++ b/settings.py
@@ -8,11 +8,12 @@ TEMPLATE_DEBUG = DEBUG
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'db',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
+        'TEST_NAME': 'submissions_test_db',
+    },
+
+    'read_replica': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'TEST_MIRROR': 'default'
     }
 }
 

--- a/submissions/tests/test_read_replica.py
+++ b/submissions/tests/test_read_replica.py
@@ -1,0 +1,42 @@
+"""
+Test API calls using the read replica.
+"""
+import copy
+from django.test import TransactionTestCase
+from submissions import api as sub_api
+
+
+class ReadReplicaTest(TransactionTestCase):
+    """ Test queries that use the read replica. """
+
+    STUDENT_ITEM = {
+        "student_id": "test student",
+        "course_id": "test course",
+        "item_id": "test item",
+        "item_type": "test type"
+    }
+
+    SCORE = {
+        "points_earned": 3,
+        "points_possible": 5
+    }
+
+    def setUp(self):
+        """ Create a submission and score. """
+        self.submission = sub_api.create_submission(self.STUDENT_ITEM, "test answer")
+        self.score = sub_api.set_score(
+            self.submission['uuid'],
+            self.SCORE["points_earned"],
+            self.SCORE["points_possible"]
+        )
+
+    def test_get_submission_and_student(self):
+        retrieved = sub_api.get_submission_and_student(self.submission['uuid'], read_replica=True)
+        expected = copy.deepcopy(self.submission)
+        expected['student_item'] = copy.deepcopy(self.STUDENT_ITEM)
+        self.assertEqual(retrieved, expected)
+
+    def test_get_latest_score_for_submission(self):
+        retrieved = sub_api.get_latest_score_for_submission(self.submission['uuid'], read_replica=True)
+        self.assertEqual(retrieved['points_possible'], self.SCORE['points_possible'])
+        self.assertEqual(retrieved['points_earned'], self.SCORE['points_earned'])


### PR DESCRIPTION
First step towards fixing [ORA-629](https://openedx.atlassian.net/browse/ORA-629)
This introduces a "read replica" option for some of the accessors we use in ORA2 data download.
I've updated the test configuration to use an on-disk SQLite database and Django's `TEST_MIRROR` setting.

@ormsbee please review.
