### PR TITLE
Use read replica and cache for top scores

### DIFF
--- a/submissions/tests/test_read_replica.py
+++ b/submissions/tests/test_read_replica.py
@@ -40,3 +40,34 @@ class ReadReplicaTest(TransactionTestCase):
         retrieved = sub_api.get_latest_score_for_submission(self.submission['uuid'], read_replica=True)
         self.assertEqual(retrieved['points_possible'], self.SCORE['points_possible'])
         self.assertEqual(retrieved['points_earned'], self.SCORE['points_earned'])
+
+    def test_get_top_submissions(self):
+        student_1 = sub_api.create_submission(self.STUDENT_ITEM, "Hello World")
+        student_2 = sub_api.create_submission(self.STUDENT_ITEM, "Hello World")
+        student_3 = sub_api.create_submission(self.STUDENT_ITEM, "Hello World")
+
+        sub_api.set_score(student_1['uuid'], 8, 10)
+        sub_api.set_score(student_2['uuid'], 4, 10)
+        sub_api.set_score(student_3['uuid'], 2, 10)
+
+        # Use the read-replica
+        with self.assertNumQueries(0):
+            top_scores = sub_api.get_top_submissions(
+                self.STUDENT_ITEM['course_id'],
+                self.STUDENT_ITEM['item_id'],
+                self.STUDENT_ITEM['item_type'], 2,
+                read_replica=True
+            )
+            self.assertEqual(
+                top_scores,
+                [
+                    {
+                        'content': "Hello World",
+                        'score': 8
+                    },
+                    {
+                        'content': "Hello World",
+                        'score': 4
+                    },
+                ]
+            )


### PR DESCRIPTION
The leaderboard feature should be able to tolerate some latency in the search results.  This PR changes the `get_top_submissions()` API call to use a cache and the read-replica by default.  The change is backwards-compatible and will require no modifications to the leaderboard PR in edx-ora2.

@stephensanchez please review.
