### PR TITLE
Don't pin the specific version of restframework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ dogapi==1.2.1
 django>=1.4,<1.5
 django-extensions==1.2.5
 django-model-utils==1.4.0
-djangorestframework==2.3.5
+djangorestframework<2.4
 pytz==2012h
 South==0.7.6


### PR DESCRIPTION
@wedaly I'm trying to resolve a dependency conflict in edx-val, tracking down instances of rest-framework that can be safely upgraded past 2.3.5
