### PR TITLE
Adding signals for scoring events.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Joe Blaylock <jrbl@stanford.edu>
 Will Daly <will@edx.org>
 David Ormsbee <dave@edx.org>
 Stephen Sanchez <steve@edx.org>
+Phil McGachey <phil_mcgachey@harvard.edu>

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -14,13 +14,24 @@ import logging
 
 from django.db import models, DatabaseError
 from django.db.models.signals import post_save
-from django.dispatch import receiver
+from django.dispatch import receiver, Signal
 from django.utils.timezone import now
 from django_extensions.db.fields import UUIDField
 
 
 logger = logging.getLogger(__name__)
 
+# Signal to inform listeners that a score has been changed
+score_set = Signal(providing_args=[
+        'points_possible', 'points_earned', 'anonymous_user_id',
+        'course_id', 'item_id'
+    ]
+)
+
+# Signal to inform listeners that a score has been reset
+score_reset = Signal(
+    providing_args=['anonymous_user_id', 'course_id', 'item_id']
+)
 
 class StudentItem(models.Model):
     """Represents a single item for a single course for a single user.


### PR DESCRIPTION
This change introduces two signals that are triggered when the set_score and reset_score operations run successfully. This is part of a larger series of changes that will send signals in the edx-platform code, in order to transmit scores to campus LMS platforms when an assignment is launched over LTI; code in the edx-platform courseware app will catch these signals in order to relay any score changes to the LTI consumer.

Tagging @ormsbee, since we've talked about this change offline.