### PR TITLE
Add the ability to annotate scores.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Will Daly <will@edx.org>
 David Ormsbee <dave@edx.org>
 Stephen Sanchez <steve@edx.org>
 Phil McGachey <phil_mcgachey@harvard.edu>
+Diana Huang <dkh@edx.org>

--- a/submissions/api.py
+++ b/submissions/api.py
@@ -10,13 +10,13 @@ import json
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db import IntegrityError, DatabaseError
+from django.db import IntegrityError, DatabaseError, transaction
 from dogapi import dog_stats_api
 
 from submissions.serializers import (
     SubmissionSerializer, StudentItemSerializer, ScoreSerializer
 )
-from submissions.models import Submission, StudentItem, Score, ScoreSummary, score_set, score_reset
+from submissions.models import Submission, StudentItem, Score, ScoreSummary, ScoreAnnotation, score_set, score_reset
 
 logger = logging.getLogger("submissions.api")
 
@@ -698,7 +698,8 @@ def reset_score(student_id, course_id, item_id):
         logger.info(msg)
 
 
-def set_score(submission_uuid, points_earned, points_possible):
+def set_score(submission_uuid, points_earned, points_possible,
+              annotation_creator=None, annotation_type=None, annotation_reason=None):
     """Set a score for a particular submission.
 
     Sets the score for a particular submission. This score is calculated
@@ -708,6 +709,11 @@ def set_score(submission_uuid, points_earned, points_possible):
         submission_uuid (str): UUID for the submission (must exist).
         points_earned (int): The earned points for this submission.
         points_possible (int): The total points possible for this particular student item.
+
+        annotation_creator (str): An optional field for recording who gave this particular score
+        annotation_type (str): An optional field for recording what type of annotation should be created,
+                                e.g. "staff_override".
+        annotation_reason (str): An optional field for recording why this score was set to its value.
 
     Returns:
         None
@@ -761,9 +767,19 @@ def set_score(submission_uuid, points_earned, points_possible):
     # even though we cannot retrieve it.
     # In this case, we assume that someone else has already created
     # a score summary and ignore the error.
+    # TODO: once we're using Django 1.8, use transactions to ensure that these
+    # two models are saved at the same time.
     try:
         score_model = score.save()
         _log_score(score_model)
+        if annotation_creator is not None:
+            score_annotation = ScoreAnnotation(
+                score=score_model,
+                creator=annotation_creator,
+                annotation_type=annotation_type,
+                reason=annotation_reason
+            )
+            score_annotation.save()
         # Send a signal out to any listeners who are waiting for scoring events.
         score_set.send(
             sender=None,

--- a/submissions/migrations/0006_auto__add_scoreannotation__chg_field_studentitem_student_id.py
+++ b/submissions/migrations/0006_auto__add_scoreannotation__chg_field_studentitem_student_id.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'ScoreAnnotation'
+        db.create_table('submissions_scoreannotation', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('score', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['submissions.Score'])),
+            ('annotation_type', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('creator', self.gf('submissions.models.AnonymizedUserIDField')(max_length=255, db_index=True)),
+            ('reason', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal('submissions', ['ScoreAnnotation'])
+
+
+        # Changing field 'StudentItem.student_id'
+        db.alter_column('submissions_studentitem', 'student_id', self.gf('submissions.models.AnonymizedUserIDField')(max_length=255))
+
+    def backwards(self, orm):
+        # Deleting model 'ScoreAnnotation'
+        db.delete_table('submissions_scoreannotation')
+
+
+        # Changing field 'StudentItem.student_id'
+        db.alter_column('submissions_studentitem', 'student_id', self.gf('django.db.models.fields.CharField')(max_length=255))
+
+    models = {
+        'submissions.score': {
+            'Meta': {'object_name': 'Score'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'points_earned': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'points_possible': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'reset': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']"}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.Submission']", 'null': 'True'})
+        },
+        'submissions.scoreannotation': {
+            'Meta': {'object_name': 'ScoreAnnotation'},
+            'annotation_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'creator': ('submissions.models.AnonymizedUserIDField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'reason': ('django.db.models.fields.TextField', [], {}),
+            'score': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.Score']"})
+        },
+        'submissions.scoresummary': {
+            'Meta': {'object_name': 'ScoreSummary'},
+            'highest': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['submissions.Score']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latest': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['submissions.Score']"}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']", 'unique': 'True'})
+        },
+        'submissions.studentitem': {
+            'Meta': {'unique_together': "(('course_id', 'student_id', 'item_id'),)", 'object_name': 'StudentItem'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'item_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'student_id': ('submissions.models.AnonymizedUserIDField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        'submissions.submission': {
+            'Meta': {'ordering': "['-submitted_at', '-id']", 'object_name': 'Submission'},
+            'answer': ('jsonfield.fields.JSONField', [], {'db_column': "'raw_answer'", 'blank': 'True'}),
+            'attempt_number': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'student_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['submissions.StudentItem']"}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '36', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['submissions']


### PR DESCRIPTION
## [TNL-3462](https://openedx.atlassian.net/browse/TNL-3462)

Add a new `ScoreAnnotation` model for annotating 'special' scores that may exist for reasons outside the typical workflow (for example: staff overrides).

### Testing
- [x] Unit, integration, acceptance tests as appropriate
- [x] Database migrations are backwards-compatible

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @andy-armstrong 
- [x] Code review: @efischer19 

FYI: @maxrothman - we're adding a new table here, @ormsbee - just in case you wanted to give it a quick once-over.

### Post-review
- [ ] Squash commits