### PR TITLE
Update the DRF version requirement to match edx-platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ dogapi==1.2.1
 django>=1.8,<1.9
 django-extensions==1.5.9
 django-model-utils==2.3.1
-djangorestframework>=3.1,<3.2
+# Use the same cherry-picked repo as edx-platform
+#djangorestframework>=3.1,<3.2
+git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 jsonfield==1.0.3
 pytz==2015.2

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-submissions',
-    version='0.1.2',
+    version='0.1.3',
     author='edX',
     description='An API for creating submissions and scores.',
     url='http://github.com/edx/edx-submissions.git',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,9 @@
 ddt==0.8.0
 django-nose==1.4.1
 mock==1.0.1
-nose==1.3.0
-coverage==3.7.1
-pep8==1.4.6
+nose==1.3.3
+coverage==4.0.2
+pep8==1.6.2
 pylint<1.0
 
 # Docs


### PR DESCRIPTION
Use the same forked version of DRF in the submissions library as edx-platform.