### PR TITLE
Soft-delete Submissions to reset student state

### DIFF
--- a/submissions/migrations/0003_submission_status.py
+++ b/submissions/migrations/0003_submission_status.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('submissions', '0002_auto_20151119_0913'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='submission',
+            name='status',
+            field=models.CharField(default=b'A', max_length=1, choices=[(b'D', b'Deleted'), (b'A', b'Active')]),
+        ),
+    ]

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -124,6 +124,27 @@ class Submission(models.Model):
     # name so it continues to use `raw_answer`.
     answer = JSONField(blank=True, db_column="raw_answer")
 
+    # Has this submission been soft-deleted? This allows instructors to reset student
+    # state on an item, while preserving the previous value for potential analytics use.
+    DELETED = 'D'
+    ACTIVE = 'A'
+    STATUS_CHOICES = (
+        (DELETED, 'Deleted'),
+        (ACTIVE, 'Active'),
+    )
+    status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=ACTIVE)
+
+    # Override the default Manager with our custom one to filter out soft-deleted items
+    class SoftDeletedManager(models.Manager):
+        def get_queryset(self):
+            return super(Submission.SoftDeletedManager, self).get_queryset().exclude(status=Submission.DELETED)
+
+    objects = SoftDeletedManager()
+
+    @staticmethod
+    def get_cache_key(sub_uuid):
+        return "submissions.submission.{}".format(sub_uuid)
+
     def __repr__(self):
         return repr(dict(
             uuid=self.uuid,

--- a/submissions/tests/test_api.py
+++ b/submissions/tests/test_api.py
@@ -573,6 +573,27 @@ class TestSubmissionsApi(TestCase):
             )
         self.assertEqual(cached_scores, scores)
 
+    def test_clear_state(self):
+        # Create a submission, give it a score, and verify that score exists
+        submission = api.create_submission(STUDENT_ITEM, ANSWER_ONE)
+        api.set_score(submission["uuid"], 11, 12)
+        score = api.get_score(STUDENT_ITEM)
+        self._assert_score(score, 11, 12)
+        self.assertEqual(score['submission_uuid'], submission['uuid'])
+
+        # Reset the score with clear_state=True
+        # This should set the submission's score to None, and make it unavailable to get_submissions
+        api.reset_score(
+            STUDENT_ITEM["student_id"],
+            STUDENT_ITEM["course_id"],
+            STUDENT_ITEM["item_id"],
+            clear_state=True,
+        )
+        score = api.get_score(STUDENT_ITEM)
+        self.assertIsNone(score)
+        subs = api.get_submissions(STUDENT_ITEM)
+        self.assertEqual(subs, [])
+
     @raises(api.SubmissionRequestError)
     def test_error_on_get_top_submissions_too_few(self):
         student_item = copy.deepcopy(STUDENT_ITEM)


### PR DESCRIPTION
Previous methods of "deleting state" for a student had just issued
reset scores, so the (unscored) submission was still hanging around.
With this change, the submission can be "deleted" for all django-
relevant purposes, while still remaining in the database in case
it turns out to be interesting to analytics later.

Supersedes https://github.com/edx/edx-submissions/pull/32.
Sibling change to https://github.com/edx/edx-platform/pull/11371 and https://github.com/edx/edx-ora2/pull/862