### PR TITLE
Clear state option

### DIFF
--- a/submissions/api.py
+++ b/submissions/api.py
@@ -689,6 +689,7 @@ def reset_score(student_id, course_id, item_id, clear_state=False):
             # sever the link between this student item and any submissions it may current have
             for sub in student_item.submission_set.all():
                 sub.student_item = None
+                sub.save(update_fields=['student_item'])
 
     except DatabaseError:
         msg = (

--- a/submissions/api.py
+++ b/submissions/api.py
@@ -643,7 +643,7 @@ def get_latest_score_for_submission(submission_uuid, read_replica=False):
     return ScoreSerializer(score).data
 
 
-def reset_score(student_id, course_id, item_id):
+def reset_score(student_id, course_id, item_id, clear_state=False):
     """
     Reset scores for a specific student on a specific problem.
 
@@ -655,6 +655,7 @@ def reset_score(student_id, course_id, item_id):
         student_id (unicode): The ID of the student for whom to reset scores.
         course_id (unicode): The ID of the course containing the item to reset.
         item_id (unicode): The ID of the item for which to reset scores.
+        clear_state (boolean): If True, unlink the Submission and StudentItem so the Submission cannot be accessed.
 
     Returns:
         None
@@ -683,6 +684,11 @@ def reset_score(student_id, course_id, item_id):
             course_id=course_id,
             item_id=item_id,
         )
+
+        if clear_state:
+            # sever the link between this student item and any submissions it may current have
+            for sub in student_item.submission_set.all():
+                sub.student_item = None
 
     except DatabaseError:
         msg = (

--- a/submissions/migrations/0003_submission_null_FK.py
+++ b/submissions/migrations/0003_submission_null_FK.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('submissions', '0002_auto_20151119_0913'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='submission',
+            name='student_item',
+            field=models.ForeignKey(to='submissions.StudentItem', null=True),
+        ),
+    ]

--- a/submissions/migrations/0003_submission_null_FK.py
+++ b/submissions/migrations/0003_submission_null_FK.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='submission',
             name='student_item',
-            field=models.ForeignKey(to='submissions.StudentItem', null=True),
+            field=models.ForeignKey(to='submissions.StudentItem', null=True, default=1),
+            preserve_default=False
         ),
     ]

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -103,7 +103,7 @@ class Submission(models.Model):
 
     uuid = UUIDField(version=1, db_index=True)
 
-    student_item = models.ForeignKey(StudentItem)
+    student_item = models.ForeignKey(StudentItem, null=True)
 
     # Which attempt is this? Consecutive Submissions do not necessarily have
     # increasing attempt_number entries -- e.g. re-scoring a buggy problem.


### PR DESCRIPTION
To fix the buggy behavior reported in TNL-3880, we need to ensure
that the submission we're dropping is unlinked from the student_item
used to find it. This prevents code (say, an ORA staff tool) from
constructing a student item with an id, a course, and a problem, and
using that to find a "cleared" submission.

[TNL-3880](https://openedx.atlassian.net/browse/PROJ-TNL-3880)
Sibling changes:
* https://github.com/edx/edx-platform/pull/11422
* https://github.com/edx/edx-ora2/pull/863