### PR TITLE
Stop pinning pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ django-model-utils==2.3.1
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 jsonfield==1.0.3
-pytz==2015.2
+pytz

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-submissions',
-    version='1.1.5',
+    version='1.1.6',
     author='edX',
     description='An API for creating submissions and scores.',
     url='http://github.com/edx/edx-submissions.git',


### PR DESCRIPTION
This is incorrectly downgrading the devstack version when installing ora:

```
Obtaining file:///edx/src/edx-submissions
Collecting pytz==2015.2 (from edx-submissions==1.1.5)
  Downloading pytz-2015.2-py2.py3-none-any.whl (476kB)
    100% |████████████████████████████████| 481kB 2.6MB/s 
Requirement already satisfied: jsonfield==1.0.3 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from edx-submissions==1.1.5)
Requirement already satisfied: django-extensions==1.5.9 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from edx-submissions==1.1.5)
Requirement already satisfied: django-model-utils==2.3.1 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from edx-submissions==1.1.5)
Requirement already satisfied: dogapi==1.2.1 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from edx-submissions==1.1.5)
Requirement already satisfied: Django<1.11 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from edx-submissions==1.1.5)
Requirement already satisfied: six>=1.2 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from django-extensions==1.5.9->edx-submissions==1.1.5)
Requirement already satisfied: decorator>=3.3.2 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from dogapi==1.2.1->edx-submissions==1.1.5)
Requirement already satisfied: simplejson>=2.0.9 in /edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages (from dogapi==1.2.1->edx-submissions==1.1.5)
Installing collected packages: pytz, edx-submissions
  Found existing installation: pytz 2016.7
    Uninstalling pytz-2016.7:
      Successfully uninstalled pytz-2016.7
  Running setup.py develop for edx-submissions
Successfully installed edx-submissions pytz-2015.2
```

I've included a version bump to fast-track releasing this.