### PR TITLE
Upgrade DRF requirement to v3.6.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 dogapi==1.2.1
 django-extensions==1.5.9
 django-model-utils==2.3.1
-# Use the same cherry-picked repo as edx-platform
-#djangorestframework>=3.1,<3.2
-git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
+# Use the same DRF version as edx-platform
+git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 jsonfield==1.0.3
 pytz

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-submissions',
-    version='2.0.0',
+    version='2.0.1',
     author='edX',
     description='An API for creating submissions and scores.',
     url='http://github.com/edx/edx-submissions.git',


### PR DESCRIPTION
As part of the Django 1.11 upgrade of edx-platform, the platform's required version of DRF needs to be upgraded. As this repo is a requirement of edx-platform and is pinned at a lower DRF version, the required version needs to be bumped here as well.

The platform will still use an edX fork of DRF - but that fork is v3.6.3 plus one patch.