### PR TITLE
Loosen requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-dogapi==1.2.1
-django-extensions==1.5.9
-django-model-utils==2.3.1
+dogapi>=1.2.1,<2.0.0
+django-model-utils>=2.3.1,<3.0.0
 # Use the same DRF version as edx-platform
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
-jsonfield==1.0.3
+jsonfield>=1.0.3,<2.0.0
 pytz

--- a/settings.py
+++ b/settings.py
@@ -52,9 +52,6 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.admindocs',
 
-    # Third party
-    'django_extensions',
-
     # Test
     'django_nose',
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-submissions',
-    version='2.0.5',
+    version='2.0.6',
     author='edX',
     description='An API for creating submissions and scores.',
     url='http://github.com/edx/edx-submissions.git',

--- a/submissions/api.py
+++ b/submissions/api.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import operator
 import json
+from uuid import UUID
 
 from django.conf import settings
 from django.core.cache import cache
@@ -222,9 +223,12 @@ def get_submission(submission_uuid, read_replica=False):
 
     """
     if not isinstance(submission_uuid, basestring):
-        raise SubmissionRequestError(
-            msg="submission_uuid ({!r}) must be a string type".format(submission_uuid)
-        )
+        if isinstance(submission_uuid, UUID):
+            submission_uuid = unicode(submission_uuid)
+        else:
+            raise SubmissionRequestError(
+                msg="submission_uuid ({!r}) must be serializable".format(submission_uuid)
+            )
 
     cache_key = Submission.get_cache_key(submission_uuid)
     try:

--- a/submissions/migrations/0001_initial.py
+++ b/submissions/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import jsonfield.fields
 import django.utils.timezone
-import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
@@ -48,7 +47,7 @@ class Migration(migrations.Migration):
             name='Submission',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('uuid', django_extensions.db.fields.UUIDField(db_index=True, version=1, editable=False, blank=True)),
+                ('uuid', models.UUIDField(db_index=True, editable=False, blank=True)),
                 ('attempt_number', models.PositiveIntegerField()),
                 ('submitted_at', models.DateTimeField(default=django.utils.timezone.now, db_index=True)),
                 ('created_at', models.DateTimeField(default=django.utils.timezone.now, editable=False, db_index=True)),

--- a/submissions/migrations/0004_remove_django_extensions.py
+++ b/submissions/migrations/0004_remove_django_extensions.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('submissions', '0003_submission_status'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='submission',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, db_index=True),
+        ),
+    ]

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -10,12 +10,12 @@ need to then generate a matching migration for it using:
 
 """
 import logging
+from uuid import uuid4
 
 from django.db import models, DatabaseError
 from django.db.models.signals import post_save
 from django.dispatch import receiver, Signal
 from django.utils.timezone import now
-from django_extensions.db.fields import UUIDField
 from jsonfield import JSONField
 
 
@@ -101,7 +101,7 @@ class Submission(models.Model):
     """
     MAXSIZE = 1024*100  # 100KB
 
-    uuid = UUIDField(version=1, db_index=True)
+    uuid = models.UUIDField(db_index=True, default=uuid4)
 
     student_item = models.ForeignKey(StudentItem)
 
@@ -196,7 +196,7 @@ class Score(models.Model):
 
         """
         if self.submission is not None:
-            return self.submission.uuid
+            return unicode(self.submission.uuid)
         else:
             return None
 

--- a/submissions/tests/test_api.py
+++ b/submissions/tests/test_api.py
@@ -48,6 +48,7 @@ class TestSubmissionsApi(TestCase):
         """
         Clear the cache.
         """
+        super(TestSubmissionsApi, self).setUp()
         cache.clear()
 
     @ddt.data(ANSWER_ONE, ANSWER_DICT)
@@ -67,9 +68,13 @@ class TestSubmissionsApi(TestCase):
         retrieved = api.get_submission_and_student(submission['uuid'])
         self.assertItemsEqual(submission, retrieved)
 
-        # Should raise an exception if the student item does not exist
-        with self.assertRaises(api.SubmissionNotFoundError):
+        # Should raise an exception if uuid is malformed
+        with self.assertRaises(api.SubmissionInternalError):
             api.get_submission_and_student(u'no such uuid')
+
+        # Should raise a different exception if the student item does not exist
+        with self.assertRaises(api.SubmissionNotFoundError):
+            api.get_submission_and_student(u'deadbeef-1234-5678-9100-1234deadbeef')
 
     def test_get_submissions(self):
         api.create_submission(STUDENT_ITEM, ANSWER_ONE)
@@ -161,9 +166,7 @@ class TestSubmissionsApi(TestCase):
 
         # Test not found
         with self.assertRaises(api.SubmissionNotFoundError):
-            api.get_submission("notarealuuid")
-        with self.assertRaises(api.SubmissionNotFoundError):
-            api.get_submission("0" * 50)  # This is bigger than our field size
+            api.get_submission("deadbeef-1234-5678-9100-1234deadbeef")
 
     @patch.object(Submission.objects, 'get')
     @raises(api.SubmissionInternalError)


### PR DESCRIPTION
@doctoryes is this a thing we do, organizationally speaking? I know it adds a bit of risk (what if the package maintainer does something evil with a minor version release?), but if everyone uses semver properly it should allow for easier upgrades. I need to loosen `dogapi` in particular in order to [do something similar for ora's requirements](https://github.com/edx/edx-ora2/blob/32a878fd89e16252275cf25ca42cc2dc1949101a/requirements/tox.txt)

(in the process of a `setup.py install` for edx-ora2)
```
Processing dependencies for ora2==1.4.8
error: dogapi 1.11.1 is installed but dogapi==1.2.1 is required by set(['edx-submissions'])
```