### PR TITLE
Use sliced all() in management command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='edx-submissions',
-    version='2.0.10',
+    version='2.0.11',
     author='edX',
     description='An API for creating submissions and scores.',
     url='http://github.com/edx/edx-submissions.git',

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -140,6 +140,7 @@ class Submission(models.Model):
             return super(Submission.SoftDeletedManager, self).get_queryset().exclude(status=Submission.DELETED)
 
     objects = SoftDeletedManager()
+    _objects = models.Manager()  # Don't use this unless you know and can explain why objects doesn't work for you
 
     @staticmethod
     def get_cache_key(sub_uuid):


### PR DESCRIPTION
While writing a similar bit of code in edx-ora2, I noticed that [filtering on `object.id` up to `id`=`total_len` does not get all entries](https://github.com/edx/edx-ora2/pull/1035/files#r132230976). This way does, and maintains the behavior of limiting the number of results returned in SQL (because [`Slicing an unevaluated QuerySet usually returns another unevaluated QuerySet`](https://docs.djangoproject.com/en/1.11/ref/models/querysets/)

@jibsheet to review, no rush