### PR TITLE
Use find_packages in setup.py to ensure that management (commands) is…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, print_function
 import os
 import sys
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 from submissions import __version__ as VERSION
 
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
     ],
-    packages=['submissions', 'submissions.migrations'],
+    packages=find_packages(include=['submissions*'], exclude=['*.test', '*.tests']),
     install_requires=load_requirements('requirements/base.in'),
     tests_require=load_requirements('requirements/test.in'),
 )

--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.0.5'
+__version__ = '3.0.6'


### PR DESCRIPTION
… loaded as a python Package (big P).

Django seems to rely on the `management/` subdirectory being installed as a `package` in a library's `setup.py` during it's management command discovery.  This change modifies `setup.py` to use `setuptools.find_packages()` to include `submission` and it's descendants (excluding test dirs) as packages for installation.