### PR TITLE
Jkantor/submissionerror

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.1.0'
+__version__ = '3.1.1'

--- a/submissions/api.py
+++ b/submissions/api.py
@@ -14,7 +14,13 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import DatabaseError, IntegrityError
 
-from submissions.errors import SubmissionInternalError, SubmissionNotFoundError, SubmissionRequestError
+from submissions.errors import (  #  pylint: disable=unused-import
+    # SubmissionError imported so that code importing this api has access
+    SubmissionError,
+    SubmissionInternalError,
+    SubmissionNotFoundError,
+    SubmissionRequestError
+)
 from submissions.models import (
     DELETED,
     Score,

--- a/submissions/api.py
+++ b/submissions/api.py
@@ -14,8 +14,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import DatabaseError, IntegrityError
 
-from submissions.errors import (  #  pylint: disable=unused-import
-    # SubmissionError imported so that code importing this api has access
+# SubmissionError imported so that code importing this api has access
+from submissions.errors import (  # pylint: disable=unused-import
     SubmissionError,
     SubmissionInternalError,
     SubmissionNotFoundError,


### PR DESCRIPTION
My refactoring of errors into errors.py in https://github.com/edx/edx-submissions/pull/110 caused some errors in the LMS because of code in the LMS importing the errors from where they no longer are.

All of the errors besides the base SubmissionError were already imported into api.py, so if we import SubmissionError, no LMS code needs to be changed.

@edx/masters-devs-gta    