### PR TITLE
Return answer as part of submissions team API for all get methods in …

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.1.2'
+__version__ = '3.1.3'

--- a/submissions/serializers.py
+++ b/submissions/serializers.py
@@ -62,8 +62,16 @@ class TeamSubmissionSerializer(serializers.ModelSerializer):
     # answer is not a part of TeamSubmission model. We populate it externally.
     answer = serializers.SerializerMethodField()
 
-    def get_answer(self, obj):  # pylint: disable=unused-argument
+    def get_answer(self, obj):
+        """
+        Regular submissions are created after a team submission. In this case, the answer is passed as part of context
+        otherwise, get the answer from its related submission. All individual submissions are identical except for
+        student data. Therefore, get the answer of the first submitter
+        """
         answer = self.context.get("answer")
+        if answer is None and obj.submissions is not None:
+            #  retrieve answer submissions from the linked submission model. There are n identical submissions
+            answer = obj.submissions.first().answer
         return answer
 
     def validate_answer(self, value):

--- a/submissions/tests/test_team_api.py
+++ b/submissions/tests/test_team_api.py
@@ -81,7 +81,7 @@ class TestTeamSubmissionsApi(TestCase):
         if create_submissions:
             for student_id in cls.user_ids:
                 student_item = cls._get_or_create_student_item(student_id, course_id=course_id, item_id=item_id)
-                SubmissionFactory.create(student_item=student_item, team_submission=team_submission)
+                SubmissionFactory.create(student_item=student_item, team_submission=team_submission, answer='Foo')
         return team_submission
 
     @classmethod
@@ -223,7 +223,8 @@ class TestTeamSubmissionsApi(TestCase):
         """
         Test that calling team_api.get_team_submission returns the expected team submission
         """
-        team_submission_model = self._make_team_submission()
+        team_submission_model = self._make_team_submission(create_submissions=True)
+
         team_submission_dict = team_api.get_team_submission(team_submission_model.uuid)
         self.assertDictEqual(
             team_submission_dict,
@@ -250,7 +251,7 @@ class TestTeamSubmissionsApi(TestCase):
         """
         Test that calling team_api.get_team_submission_for_team returns the expected team submission
         """
-        team_submission = self._make_team_submission()
+        team_submission = self._make_team_submission(create_submissions=True)
         team_submission_dict = team_api.get_team_submission_for_team(COURSE_ID, ITEM_1_ID, TEAM_1_ID)
         self.assertDictEqual(
             team_submission_dict,


### PR DESCRIPTION
We need the api to return answer as part of the "get" team submission methods in addition to create. This dependency is present in the ORA codes. After this change is merged/release made, ORA must be updated to use the new version.