### PR TITLE
Fixing: allow_tags attribute on methods of ModelAdmin has been deprecated

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.1.4'
+__version__ = '3.1.5'

--- a/submissions/admin.py
+++ b/submissions/admin.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 from django.contrib import admin
 from django.urls import reverse
+from django.utils.html import format_html
 
 from submissions.models import Score, ScoreSummary, StudentItem, Submission
 
@@ -34,8 +35,8 @@ class StudentItemAdminMixin(object):  # pylint: disable=useless-object-inheritan
             'admin:submissions_studentitem_change',
             args=[obj.student_item.id]
         )
-        return u'<a href="{}">{}</a>'.format(url, obj.student_item.id)
-    student_item_id.allow_tags = True
+        return format_html(u'<a href="{}">{}</a>'.format(url, obj.student_item.id))
+
     student_item_id.admin_order_field = 'student_item__id'
     student_item_id.short_description = 'S.I. ID'
 
@@ -116,16 +117,16 @@ class ScoreSummaryAdmin(admin.ModelAdmin, StudentItemAdminMixin):
         url = reverse(
             'admin:submissions_score_change', args=[score_summary.highest.id]
         )
-        return u'<a href="{}">{}</a>'.format(url, score_summary.highest)
-    highest_link.allow_tags = True
+        return format_html(u'<a href="{}">{}</a>'.format(url, score_summary.highest))
+
     highest_link.short_description = 'Highest'
 
     def latest_link(self, score_summary):
         url = reverse(
             'admin:submissions_score_change', args=[score_summary.latest.id]
         )
-        return u'<a href="{}">{}</a>'.format(url, score_summary.latest)
-    latest_link.allow_tags = True
+        return format_html(u'<a href="{}">{}</a>'.format(url, score_summary.latest))
+
     latest_link.short_description = 'Latest'
 
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1619

The allow_tags attribute on methods of ModelAdmin has been deprecated.
Use format_html instead.