### PR TITLE
EDUCATOR-5059: Teams Submissions are using usernames for submission student_id rather than anonymous user ids

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.1.6'
+__version__ = '3.1.7'

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -34,6 +34,19 @@ def create_submission_for_team(
     This means that the ORA `SubmissionMixin` must first collect all of the files of the submitting user
     and the team into the `answer` dict.
 
+    Parameters:
+        - course_id (str): the course id for this team submission
+        - item_id (str): the item id for this team submission
+        - team_id (str): the team_id for the team for which we are making the submission
+        - submitting_user_id (User): the user who has hit the "submit" button
+        - team_member_ids (list of str): a list of the anonymous user ids associated with all members of the team
+        - answer (json serializable object): string, dict, or other json-serializable object that represents the team's
+                                             answer to the problem
+        - submitted_at (datetime): (optional [default = now]) the datetime at which the team submission was submitted
+        - attempt number (int): (optional [default = 1]) the attempt number for this submission
+        - item_type (str): (optional [default = 'openassessment']) the type of item for which this submission is being
+                                                                   submitted
+
     Returns:
         dict: A representation of the created TeamSubmission, with the following keys:
           'team_submission_uuid' Is the `uuid` field of the created `TeamSubmission`.


### PR DESCRIPTION
[EDUCATOR-5059](https://openedx.atlassian.net/browse/EDUCATOR-5059)

Submissions didn't really have much functional change that needed to be done, since it more or less just takes what it's given and stores it, but I wanted to clarify some stuff in the docstring, and change the tests to be reflective of how we actually want the api to be used.

@edx/masters-devs-gta   