### PR TITLE
add function to team api to reset scores

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.1.8'
+__version__ = '3.1.9'

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -277,7 +277,7 @@ def validate_only_one_submission_per_team(sender, **kwargs):
             item_id=ts.item_id,
             team_id=ts.team_id,
             status='A'
-    ).exists():
+    ).exclude(id=ts.id).exists():
         raise DuplicateTeamSubmissionsError('Can only have one submission per team.')
 
 

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -7,8 +7,8 @@ import logging
 from django.db import DatabaseError, transaction
 
 from submissions import api as _api
-from submissions.errors import TeamSubmissionInternalError, TeamSubmissionRequestError, SubmissionInternalError
-from submissions.models import TeamSubmission, DELETED
+from submissions.errors import SubmissionInternalError, TeamSubmissionInternalError, TeamSubmissionRequestError
+from submissions.models import DELETED, TeamSubmission
 from submissions.serializers import TeamSubmissionSerializer
 
 logger = logging.getLogger(__name__)

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -273,7 +273,7 @@ def reset_scores(team_submission_uuid, clear_state=False):
 
     Args:
         team_submission_uuid (str): The uuid for the team submission for which to reset scores.
-        clear_state (bool): If True, will appear to delete the team submission and any individual submissions
+        clear_state (bool): If True, soft delete the team submission and any individual submissions
                             by setting their status to DELETED
 
     Returns:
@@ -299,12 +299,12 @@ def reset_scores(team_submission_uuid, clear_state=False):
             team_submission.save(update_fields=["status"])
     except (DatabaseError, SubmissionInternalError):
         msg = (
-            u"Error occurred while reseting scores for team submission {team_submission_uuid}"
+            "Error occurred while reseting scores for team submission {team_submission_uuid}"
         ).format(team_submission_uuid=team_submission_uuid)
         logger.exception(msg)
         raise TeamSubmissionInternalError(msg)
     else:
-        msg = u"Score reset for team submission {team_submission_uuid}".format(
+        msg = "Score reset for team submission {team_submission_uuid}".format(
             team_submission_uuid=team_submission_uuid
         )
         logger.info(msg)


### PR DESCRIPTION
as a part of https://openedx.atlassian.net/browse/EDUCATOR-5031 I added a function that given a team submission uuid, calls api.reset_score for each submission

@edx/masters-devs-gta 