### PR TITLE
Return a team submission given regular submission uuid associated with it

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.1.9'
+__version__ = '3.1.10'

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -7,7 +7,12 @@ import logging
 from django.db import DatabaseError, transaction
 
 from submissions import api as _api
-from submissions.errors import SubmissionInternalError, TeamSubmissionInternalError, TeamSubmissionRequestError
+from submissions.errors import (
+    SubmissionInternalError,
+    TeamSubmissionInternalError,
+    TeamSubmissionNotFoundError,
+    TeamSubmissionRequestError
+)
 from submissions.models import DELETED, TeamSubmission
 from submissions.serializers import TeamSubmissionSerializer
 
@@ -184,6 +189,21 @@ def get_team_submission(team_submission_uuid):
         - TeamSubmissionInternalError if there is some other error looking up the team submission.
     """
     team_submission = TeamSubmission.get_team_submission_by_uuid(team_submission_uuid)
+    return TeamSubmissionSerializer(team_submission).data
+
+
+def get_team_submission_from_individual_submission(individual_submission_uuid):
+    """
+    Returns a single, serialized, team submission for the individual submission uuid.
+
+    Raises:
+        - TeamSubmissionNotFoundError when no such team submission exists.
+        - TeamSubmissionInternalError if there is some other error looking up the team submission.
+    """
+    team_submission = TeamSubmission.objects.filter(submissions__uuid=individual_submission_uuid).first()
+    if not team_submission:
+        raise TeamSubmissionNotFoundError
+
     return TeamSubmissionSerializer(team_submission).data
 
 

--- a/submissions/tests/test_read_replica.py
+++ b/submissions/tests/test_read_replica.py
@@ -27,10 +27,10 @@ def _mock_use_read_replica(queryset):
 class ReadReplicaTest(TransactionTestCase):
     """ Test queries that use the read replica. """
     STUDENT_ITEM = {
-        "student_id": "test student",
-        "course_id": "test course",
-        "item_id": "test item",
-        "item_type": "test type"
+        "student_id": "test_student",
+        "course_id": "test_course",
+        "item_id": "test_item",
+        "item_type": "test_type"
     }
 
     SCORE = {

--- a/submissions/tests/test_team_api.py
+++ b/submissions/tests/test_team_api.py
@@ -237,6 +237,26 @@ class TestTeamSubmissionsApi(TestCase):
             TeamSubmissionSerializer(team_submission_model).data
         )
 
+    def test_get_team_submission_from_individual_submission(self):
+        """
+        Test that calling team_api.get_team_submission_from_individual_submission returns the expected team submission
+        """
+        team_submission_model = self._make_team_submission(create_submissions=True)
+        regular_submission_uuid = team_submission_model.submissions.first().uuid
+        team_submission_dict = team_api.get_team_submission_from_individual_submission(regular_submission_uuid)
+        self.assertDictEqual(
+            team_submission_dict,
+            TeamSubmissionSerializer(team_submission_model).data
+        )
+
+    def test_get_team_submission_from_individual_submission_exception(self):
+        """
+        Test that calling team_api.get_team_submission when there is no matching TeamSubmission will
+        raise a TeamSubmissionNotFoundError
+        """
+        with self.assertRaises(TeamSubmissionNotFoundError):
+            team_api.get_team_submission_from_individual_submission('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+
     def test_get_team_submission_missing(self):
         """
         Test that calling team_api.get_team_submission when there is no matching TeamSubmission will


### PR DESCRIPTION
In ORA2, there are cases where we need to retrieve a team submission given regular submission uuid associated with it. This API method does it.
[Jira](https://openedx.atlassian.net/browse/EDUCATOR-5089)

@edx/masters-devs-gta 