### PR TITLE
Fixing django3.0 warning

### DIFF
--- a/submissions/models.py
+++ b/submissions/models.py
@@ -105,7 +105,7 @@ class UpdatedJSONField(JSONField):
     # because we're using jsonfield2 version 3.0.3 and it has a known issue while performing
     # select_related queries, it has been fixed in version 3.1.0 but python3.5 support is also
     # dropped in that version, for now we've put the fix here
-    def from_db_value(self, value, expression, connection, context=None):
+    def from_db_value(self, value, expression, connection):  # pylint: disable=unused-argument, arguments-differ
         if value is None:
             return None
         return json.loads(value, **self.load_kwargs)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1916
Remove the context parameter from UpdatedJSONField.from_db_value().