### PR TITLE
add get_submissions_from_other_teams

### DIFF
--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -138,15 +138,14 @@ def create_submission_for_team(
         'item_type': item_type
     }
 
-    students_with_team_submissions = {student_item.student_id for student_item in StudentItem.objects.filter(
-        submission__team_submission__isnull=False
-    ).exclude(
-        submission__team_submission__team_id=team_id
-    ).filter(
-        student_id__in=team_member_ids,
-        course_id=course_id,
-        item_id=item_id
-    )}
+    students_with_team_submissions = [
+        submission['student_id'] for submission in get_submissions_from_other_teams(
+            team_member_ids,
+            team_id,
+            item_id,
+            course_id
+        )
+    ]
     for team_member_id in team_member_ids:
         if team_member_id in students_with_team_submissions:
             continue
@@ -190,6 +189,40 @@ def _log_team_submission(team_submission_data):
             submitted_by=team_submission_data["submitted_by"],
         )
     )
+
+
+def get_submissions_from_other_teams(
+    team_member_ids,
+    team_id,
+    item_id,
+    course_id,
+):
+    """
+    This api function returns a list of objects for students on this team that have submitted
+    a response to the given item under another team.
+
+    Parameters:
+        - team_member_ids (list of str): a list of the anonymous user ids associated with all members of the team
+        - team_id (str): the team_id for the team for which we are making the submission
+        - item_id (str): the item id for this team submission
+        - course_id (str): the course id for this team submission
+
+    Returns:
+        set: { 'student_id', 'team_id' }
+    """
+    items = StudentItem.objects.filter(
+        submission__team_submission__isnull=False
+    ).exclude(
+        submission__team_submission__team_id=team_id
+    ).filter(
+        student_id__in=team_member_ids,
+        course_id=course_id,
+        item_id=item_id
+    ).values("student_id", "submission__team_submission__team_id")
+    return [{
+        'student_id': item['student_id'],
+        'team_id': item['submission__team_submission__team_id']
+    } for item in items]
 
 
 def get_team_submission(team_submission_uuid):

--- a/submissions/tests/test_team_api.py
+++ b/submissions/tests/test_team_api.py
@@ -261,6 +261,44 @@ class TestTeamSubmissionsApi(TestCase):
         self.assertEqual(TeamSubmission.objects.count(), 0)
         self.assertEqual(Submission.objects.count(), 0)
 
+    def test_get_submissions_from_other_teams(self):
+        # Make a team submission with default users, under TEAM_1
+        self._make_team_submission(
+            attempt_number=1,
+            course_id=COURSE_ID,
+            item_id=ITEM_1_ID,
+            team_id=TEAM_1_ID,
+            status=None,
+            create_submissions=True
+        )
+        # Check against TEAM_2 with 2 additional user IDs added (that don't have a submission)
+        team_ids = [
+            self.anonymous_user_id_map[student] for student in [
+                self.user_1, self.user_2, self.user_3, self.user_4
+            ]
+        ] + ['55555555555555', '666666666666666666']
+        external_submissions = team_api.get_submissions_from_other_teams(
+            team_ids,
+            TEAM_2_ID,
+            ITEM_1_ID,
+            COURSE_ID
+        )
+
+        # Should get 1 entry for each of the default users
+        self.assertEqual(len(external_submissions), 4)
+        def check_submission(submission, user):
+            self.assertEqual(
+                submission,
+                {
+                    'student_id': self.anonymous_user_id_map[user],
+                    'team_id': TEAM_1_ID
+                }
+            )
+        check_submission(external_submissions[0], self.user_1)
+        check_submission(external_submissions[1], self.user_2)
+        check_submission(external_submissions[2], self.user_3)
+        check_submission(external_submissions[3], self.user_4)
+
     def test_get_team_submission(self):
         """
         Test that calling team_api.get_team_submission returns the expected team submission


### PR DESCRIPTION
#What does this do?
Provides a new api method from the submission team_api that returns a list of objects for each student in a given team with a submission to a given item made from another team.
Returned values include the student_id as well as the team_id as there are different consumers for this data.

FIY: @edx/masters-devs-gta