### PR TITLE
fix: attempt to optimize get_team_submission_student_ids

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.4.1'
+__version__ = '3.4.2'

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -302,13 +302,14 @@ def get_team_submission_student_ids(team_submission_uuid):
     if not team_submission_uuid:
         raise TeamSubmissionNotFoundError()
     try:
-        student_ids = StudentItem.objects.filter(
-            submission__team_submission__uuid=team_submission_uuid
-        ).order_by(
-            'student_id'
-        ).distinct().values_list(
-            'student_id', flat=True
+        student_ids = TeamSubmission.objects.prefetch_related(
+            'submissions__student_item'
+        ).filter(
+            uuid=team_submission_uuid
+        ).values_list(
+            'submissions__student_item__student_id', flat=True
         )
+
     except DatabaseError as exc:
         err_msg = "Attempt to get student ids for team submission {team_submission_uuid} caused error: {exc}".format(
             team_submission_uuid=team_submission_uuid,

--- a/submissions/team_api.py
+++ b/submissions/team_api.py
@@ -302,9 +302,7 @@ def get_team_submission_student_ids(team_submission_uuid):
     if not team_submission_uuid:
         raise TeamSubmissionNotFoundError()
     try:
-        student_ids = TeamSubmission.objects.prefetch_related(
-            'submissions__student_item'
-        ).filter(
+        student_ids = TeamSubmission.objects.filter(
             uuid=team_submission_uuid
         ).values_list(
             'submissions__student_item__student_id', flat=True

--- a/submissions/tests/test_team_api.py
+++ b/submissions/tests/test_team_api.py
@@ -613,15 +613,14 @@ class TestTeamSubmissionsApi(TestCase):
         for student_id in submission_2_student_ids:
             self._make_individual_submission(student_id, team_submission=team_submission_2)
 
+        with self.assertNumQueries(1):
+            team_1_ids = team_api.get_team_submission_student_ids(str(team_submission.uuid))
+
+        team_2_ids = team_api.get_team_submission_student_ids(str(team_submission_2.uuid))
+
         # Assert that each team submission's uuid returns the correct student_ids
-        self.assertEqual(
-            team_api.get_team_submission_student_ids(str(team_submission.uuid)),
-            self.student_ids
-        )
-        self.assertEqual(
-            team_api.get_team_submission_student_ids(str(team_submission_2.uuid)),
-            submission_2_student_ids
-        )
+        self.assertEqual(team_1_ids, self.student_ids)
+        self.assertEqual(team_2_ids, submission_2_student_ids)
 
     def test_get_team_submission_student_ids__no_team_submission(self):
         with self.assertRaises(TeamSubmissionNotFoundError):


### PR DESCRIPTION
The old get_team_submission_student_ids query would take around 40 seconds. This takes 3 seconds, which is still not good, but it's better.