### PR TITLE
fix: Restore missing error export

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.11.0'
+__version__ = '3.11.1'

--- a/submissions/api.py
+++ b/submissions/api.py
@@ -15,6 +15,7 @@ from django.db import DatabaseError, IntegrityError, transaction
 # SubmissionError imported so that code importing this api has access
 from submissions.errors import (  # pylint: disable=unused-import
     ExternalGraderQueueEmptyError,
+    SubmissionError,
     SubmissionInternalError,
     SubmissionNotFoundError,
     SubmissionRequestError


### PR DESCRIPTION
This was removed in 3.11.0 but should remain re-exported for edx-platform and any other users.