### PR TITLE
chore: drop Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: ['3.11', '3.12']
+        python-version: ['3.12']
         toxenv: [quality, docs, django42-drf315, django42-drflatest, django52-drf315, django52-drflatest]
 
     steps:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.11.1
     # via django
-django==4.2.28
+django==5.2.12
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -22,7 +22,7 @@ edx-django-release-util==1.5.0
     # via -r requirements/base.in
 jsonfield==3.2.0
     # via -r requirements/base.in
-pytz==2025.2
+pytz==2026.1.post1
     # via -r requirements/base.in
 pyyaml==6.0.3
     # via edx-django-release-util

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,64 +4,84 @@
 #
 #    make upgrade
 #
-cachetools==7.0.1
+annotated-doc==0.0.4
+    # via typer
+cachetools==7.0.3
     # via
     #   -r requirements/tox.txt
     #   tox
-certifi==2026.1.4
+certifi==2026.2.25
     # via requests
-chardet==5.2.0
-    # via
-    #   -r requirements/tox.txt
-    #   tox
-charset-normalizer==3.4.4
+charset-normalizer==3.4.5
     # via requests
+click==8.3.1
+    # via typer
 colorama==0.4.6
     # via
     #   -r requirements/tox.txt
     #   tox
 coverage[toml]==7.13.4
     # via coveralls
-coveralls==4.0.2
+coveralls==4.1.0
     # via -r requirements/ci.in
 distlib==0.4.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-docopt==0.6.2
-    # via coveralls
-filelock==3.20.3
+filelock==3.25.0
     # via
     #   -r requirements/tox.txt
+    #   python-discovery
     #   tox
     #   virtualenv
 idna==3.11
     # via requests
+markdown-it-py==4.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 packaging==26.0
     # via
     #   -r requirements/tox.txt
     #   pyproject-api
     #   tox
-platformdirs==4.5.1
+platformdirs==4.9.4
     # via
     #   -r requirements/tox.txt
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via
     #   -r requirements/tox.txt
     #   tox
+pygments==2.19.2
+    # via rich
 pyproject-api==1.10.0
     # via
     #   -r requirements/tox.txt
     #   tox
+python-discovery==1.1.0
+    # via
+    #   -r requirements/tox.txt
+    #   virtualenv
 requests==2.32.5
     # via coveralls
-tox==4.34.1
+rich==14.3.3
+    # via typer
+shellingham==1.5.4
+    # via typer
+tomli-w==1.2.0
+    # via
+    #   -r requirements/tox.txt
+    #   tox
+tox==4.49.0
     # via -r requirements/tox.txt
+typer==0.24.1
+    # via coveralls
 urllib3==2.6.3
     # via requests
-virtualenv==20.36.1
+virtualenv==21.1.0
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -17,15 +17,9 @@
 #  this file from Github directly. It does not require packaging in edx-lint.
 
 # using LTS django version
-Django<5.0
+Django<6.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
-
-# pip 26 is incompatible with pip-tools hence causing failures during the build process
-# Make upgrade command and all requirements upgrade jobs are broken due to this.
-# The constraint can be removed once a release (pip-tools > 7.5.2) is available with support for pip 26
-# Issue to track this dependency and unpin later on: https://github.com/jazzband/pip-tools/issues/2319
-pip<26.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -40,7 +40,7 @@ beautifulsoup4==4.14.3
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -49,7 +49,7 @@ cffi==2.0.0
     # via
     #   -r requirements/test.txt
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.4.5
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -65,7 +65,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -79,7 +79,7 @@ dill==0.4.1
     # via
     #   -r requirements/test.txt
     #   pylint
-django==4.2.28
+django==5.2.12
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -136,14 +136,14 @@ edx-django-utils==8.0.1
     #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/test.txt
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
     #   openedx-events
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==40.4.0
+faker==40.8.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -158,7 +158,7 @@ idna==3.11
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -167,7 +167,7 @@ iniconfig==2.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==7.0.0
+isort==8.0.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -202,7 +202,7 @@ packaging==26.0
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-platformdirs==4.5.1
+platformdirs==4.9.4
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -239,7 +239,7 @@ pygments==2.19.2
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pylint==4.0.4
+pylint==4.0.5
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -274,7 +274,7 @@ pytest==9.0.2
     #   pytest-django
 pytest-cov==7.0.0
     # via -r requirements/test.txt
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
@@ -284,7 +284,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2025.2
+pytz==2026.1.post1
     # via
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
@@ -328,7 +328,7 @@ soupsieve==2.8
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==9.0.4
+sphinx==9.1.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -378,7 +378,7 @@ sqlparse==0.5.5
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   -r requirements/test.txt
     #   code-annotations

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,11 +18,11 @@ babel==2.18.0
     #   sphinx
 beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-certifi==2026.1.4
+certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.5
     # via requests
-django==4.2.28
+django==5.2.12
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -42,7 +42,7 @@ edx-django-release-util==1.5.0
     # via -r requirements/base.txt
 idna==3.11
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via sphinx
@@ -63,7 +63,7 @@ pygments==2.19.2
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
-pytz==2025.2
+pytz==2026.1.post1
     # via -r requirements/base.txt
 pyyaml==6.0.3
     # via
@@ -85,7 +85,7 @@ soupsieve==2.8
     # via
     #   -c requirements/constraints.txt
     #   beautifulsoup4
-sphinx==9.0.4
+sphinx==9.1.0
     # via
     #   -r requirements/docs.in
     #   pydata-sphinx-theme

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -12,7 +12,7 @@ packaging==26.0
     # via
     #   build
     #   wheel
-pip-tools==7.5.2
+pip-tools==7.5.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,9 +10,7 @@ wheel==0.46.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+pip==26.0.1
+    # via -r requirements/pip.in
 setuptools==82.0.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,13 +32,13 @@ beautifulsoup4==4.14.3
     # via
     #   -r requirements/docs.txt
     #   pydata-sphinx-theme
-certifi==2026.1.4
+certifi==2026.2.25
     # via
     #   -r requirements/docs.txt
     #   requests
 cffi==2.0.0
     # via pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.4.5
     # via
     #   -r requirements/docs.txt
     #   requests
@@ -50,7 +50,7 @@ click==8.3.1
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via edx-lint
 coverage[toml]==7.13.4
     # via pytest-cov
@@ -98,13 +98,13 @@ edx-django-utils==8.0.1
     # via openedx-events
 edx-lint==5.6.0
     # via -r requirements/test.in
-edx-opaque-keys[django]==3.0.0
+edx-opaque-keys[django]==3.1.0
     # via
     #   edx-ccx-keys
     #   openedx-events
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==40.4.0
+faker==40.8.0
     # via factory-boy
 fastavro==1.12.1
     # via openedx-events
@@ -114,13 +114,13 @@ idna==3.11
     # via
     #   -r requirements/docs.txt
     #   requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
 iniconfig==2.3.0
     # via pytest
-isort==7.0.0
+isort==8.0.1
     # via
     #   -r requirements/test.in
     #   pylint
@@ -149,7 +149,7 @@ packaging==26.0
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-platformdirs==4.5.1
+platformdirs==4.9.4
     # via pylint
 pluggy==1.6.0
     # via
@@ -176,7 +176,7 @@ pygments==2.19.2
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pylint==4.0.4
+pylint==4.0.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -200,7 +200,7 @@ pytest==9.0.2
     #   pytest-django
 pytest-cov==7.0.0
     # via -r requirements/test.in
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
@@ -208,7 +208,7 @@ python-dateutil==2.9.0.post0
     #   freezegun
 python-slugify==8.0.4
     # via code-annotations
-pytz==2025.2
+pytz==2026.1.post1
     # via
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
@@ -245,7 +245,7 @@ soupsieve==2.8
     #   -c requirements/constraints.txt
     #   -r requirements/docs.txt
     #   beautifulsoup4
-sphinx==9.0.4
+sphinx==9.1.0
     # via
     #   -r requirements/docs.txt
     #   pydata-sphinx-theme
@@ -283,7 +283,7 @@ sqlparse==0.5.5
     #   -r requirements/base.txt
     #   -r requirements/docs.txt
     #   django
-stevedore==5.6.0
+stevedore==5.7.0
     # via
     #   code-annotations
     #   edx-django-utils

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,31 +4,35 @@
 #
 #    make upgrade
 #
-cachetools==7.0.1
-    # via tox
-chardet==5.2.0
+cachetools==7.0.3
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.20.3
+filelock==3.25.0
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
 packaging==26.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.5.1
+platformdirs==4.9.4
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-tox==4.34.1
+python-discovery==1.1.0
+    # via virtualenv
+tomli-w==1.2.0
+    # via tox
+tox==4.49.0
     # via -r requirements/tox.in
-virtualenv==20.36.1
+virtualenv==21.1.0
     # via tox

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],
     packages=find_packages(include=['submissions*'], exclude=['*.test', '*.tests']),

--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '3.12.2'
+__version__ = '4.0.0'


### PR DESCRIPTION
## Summary

- Drop Python 3.11 support: remove from CI test matrix, tox envlist, and package classifiers
- Regenerate pinned requirements using Python 3.12
- Bump version to 4.0.0 — dropping Python support is a breaking change, so this is a major version bump

## Context

Python 3.11 is being dropped across the Open edX ecosystem as part of the move
to standardize on Python 3.12. See the tracking issue for the full list of repos:
https://github.com/openedx/public-engineering/issues/499

## Test plan

- [ ] CI passes with Python 3.12 only