### PR TITLE
fix: scale grader's pass-ratio score into points_earned in put_result

### DIFF
--- a/submissions/__init__.py
+++ b/submissions/__init__.py
@@ -1,2 +1,2 @@
 """ API for creating submissions and scores. """
-__version__ = '4.0.1'
+__version__ = '4.0.2'

--- a/submissions/tests/test_viewsets.py
+++ b/submissions/tests/test_viewsets.py
@@ -360,6 +360,36 @@ class TestXqueueViewSet(APITestCase):
         self.assertEqual(score.points_earned, 7)
         self.assertEqual(score.points_possible, 10)
 
+    def test_put_result_missing_score_skips_scaling(self):
+        """
+        A grader reply with no "score" key parses to points_earned=None.
+        put_result must not try to scale None by points_possible (that
+        would raise TypeError) -- it should leave it as None and let the
+        existing set_score() failure handling take over, same as any other
+        invalid score value.
+        """
+        self.client.login(username="testuser", password="testpass")
+        response = self.client.post(self.url_status)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.external_grader.update_status("pulled")
+
+        payload = {
+            "xqueue_header": json.dumps(
+                {
+                    "submission_id": self.submission.id,
+                    "submission_key": self.external_grader.pullkey,
+                }
+            ),
+            "xqueue_body": json.dumps({}),
+        }
+
+        response = self.client.post(self.url_put_result, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.external_grader.refresh_from_db()
+        self.assertEqual(self.external_grader.num_failures, 1)
+        self.assertEqual(self.external_grader.status, "retry")
+
     def test_login_success(self):
         """Test successful login"""
         data = {"username": "testuser", "password": "testpass"}

--- a/submissions/tests/test_viewsets.py
+++ b/submissions/tests/test_viewsets.py
@@ -17,7 +17,7 @@ from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.test import APIClient, APITestCase
 
-from submissions.models import ExternalGraderDetail, SubmissionFile
+from submissions.models import ExternalGraderDetail, Score, SubmissionFile
 from submissions.permissions import IsXQueueUser
 from submissions.tests.factories import ExternalGraderDetailFactory, SubmissionFactory
 from submissions.views.xqueue import MAX_SCORE_UPDATE_RETRIES, XQueueViewSet
@@ -318,6 +318,47 @@ class TestXqueueViewSet(APITestCase):
         self.assertEqual(response_data, self.viewset.compose_reply(True, ""))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_put_result_scales_fractional_score_to_points_earned(self):
+        """
+        Graders report a 0.0-1.0 pass-ratio (e.g. tests_passed / tests_total),
+        not an absolute point count. put_result must scale that fraction by
+        points_possible before handing it to set_score(), which requires an
+        integer. Regression test for a bug where the raw fraction was passed
+        straight through, causing set_score() to reject every submission
+        (correct or not) for any problem worth more than 1 point.
+        """
+        external_grader = ExternalGraderDetailFactory(
+            submission=SubmissionFactory(),
+            pullkey="fractional_pull_key",
+            status="pulled",
+            queue_name="test_queue",
+            num_failures=0,
+            points_possible=10,
+        )
+
+        payload = {
+            "xqueue_header": json.dumps(
+                {
+                    "submission_id": external_grader.submission.id,
+                    "submission_key": "fractional_pull_key",
+                }
+            ),
+            "xqueue_body": json.dumps({"score": 0.7}),
+        }
+
+        self.client.login(username="testuser", password="testpass")
+        response = self.client.post(self.url_put_result, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data, self.viewset.compose_reply(True, ""))
+
+        score = Score.objects.filter(
+            student_item=external_grader.submission.student_item
+        ).latest("created_at")
+        self.assertEqual(score.points_earned, 7)
+        self.assertEqual(score.points_possible, 10)
 
     def test_login_success(self):
         """Test successful login"""

--- a/submissions/tests/test_viewsets.py
+++ b/submissions/tests/test_viewsets.py
@@ -390,6 +390,39 @@ class TestXqueueViewSet(APITestCase):
         self.assertEqual(self.external_grader.num_failures, 1)
         self.assertEqual(self.external_grader.status, "retry")
 
+    def test_put_result_non_numeric_score_treated_as_failure(self):
+        """
+        validate_grader_reply() does not enforce "score" to be numeric, so a
+        malformed grader reply can hand put_result a string/dict/list for
+        points_earned. Regression test for a bug where scaling that value ran
+        outside the try/except around set_score(), so a non-numeric score
+        raised an unhandled TypeError (500) instead of going through the same
+        retry/failure path as any other invalid score.
+        """
+        self.client.login(username="testuser", password="testpass")
+        response = self.client.post(self.url_status)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.external_grader.update_status("pulled")
+
+        payload = {
+            "xqueue_header": json.dumps(
+                {
+                    "submission_id": self.submission.id,
+                    "submission_key": self.external_grader.pullkey,
+                }
+            ),
+            "xqueue_body": json.dumps({"score": "not_a_number"}),
+        }
+
+        response = self.client.post(self.url_put_result, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = json.loads(response.content)
+        self.assertEqual(response_data, self.viewset.compose_reply(True, ""))
+        self.external_grader.refresh_from_db()
+        self.assertEqual(self.external_grader.num_failures, 1)
+        self.assertEqual(self.external_grader.status, "retry")
+
     def test_login_success(self):
         """Test successful login"""
         data = {"username": "testuser", "password": "testpass"}

--- a/submissions/views/xqueue.py
+++ b/submissions/views/xqueue.py
@@ -297,14 +297,6 @@ class XQueueViewSet(viewsets.ViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        # `points_earned` from the grader is a 0.0-1.0 pass-ratio fraction (see
-        # xqueue-watcher's grader_support.entrypoint), not an absolute point count.
-        # Scale it by the problem's points_possible and round to the nearest
-        # integer to match set_score()'s integer point contract; otherwise
-        # ScoreSerializer rejects it and every submission fails.
-        if points_earned is not None:
-            points_earned = round(points_earned * external_grader.points_possible)
-
         # pylint: disable=broad-exception-caught
         submission_context = {
             "submission_id": submission_id,
@@ -316,6 +308,17 @@ class XQueueViewSet(viewsets.ViewSet):
         }
 
         try:
+            # `points_earned` from the grader is a 0.0-1.0 pass-ratio fraction (see
+            # xqueue-watcher's grader_support.entrypoint), not an absolute point count.
+            # Scale it by the problem's points_possible and round to the nearest
+            # integer to match set_score()'s integer point contract; otherwise
+            # ScoreSerializer rejects it and every submission fails. Do this inside
+            # the try block: validate_grader_reply() does not enforce points_earned
+            # to be numeric, so a malformed grader reply must hit the same
+            # retry/failure handling as a set_score() failure, not a raw 500.
+            if points_earned is not None:
+                points_earned = round(points_earned * external_grader.points_possible)
+
             log.info(
                 "Attempting to record score for submission %(submission_id)s "
                 "(course=%(course_id)s, item=%(item_id)s, user=%(user_id)s)",

--- a/submissions/views/xqueue.py
+++ b/submissions/views/xqueue.py
@@ -297,6 +297,14 @@ class XQueueViewSet(viewsets.ViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        # `points_earned` from the grader is a 0.0-1.0 pass-ratio fraction (see
+        # xqueue-watcher's grader_support.entrypoint), not an absolute point count.
+        # Scale it by the problem's points_possible and round to the nearest
+        # integer to match set_score()'s integer point contract; otherwise
+        # ScoreSerializer rejects it and every submission fails.
+        if points_earned is not None:
+            points_earned = round(points_earned * external_grader.points_possible)
+
         # pylint: disable=broad-exception-caught
         submission_context = {
             "submission_id": submission_id,


### PR DESCRIPTION
Fixes #365

## Summary

`XQueueViewSet.put_result` takes the grader's `score` field directly from `xqueue_body` and passes it to `set_score()` as `points_earned`, without scaling by the problem's `points_possible`.

External graders following the xqueue-watcher protocol report `score` as a 0.0–1.0 pass-ratio (`grader_support/entrypoint.py`: `results["score"] = float(sum(corrects)) / n`), not an absolute point count. `set_score()` expects `points_earned` as an integer point count (see its own docstring example: `set_score(uuid, 11, 12)`), and its `ScoreSerializer` validates `points_earned` as a Django `IntegerField`.

`IntegerField.to_internal_value` does `int(str(data))`. For any float — including whole-valued ones like `1.0` — this raises `ValueError` (`int("1.0")` fails), so `set_score()` raises `SubmissionInternalError` and **every** submission through `put_result` fails whenever `points_possible != 1`, correct or not.

## Fix

Scale `points_earned` by `external_grader.points_possible` and round to the nearest integer, right after the pullkey check confirms `external_grader` (and thus `points_possible`) is available, before it's handed to `set_score()`.

## Why existing tests didn't catch this

- `test_put_result_success` is the only test that exercises `put_result` without mocking `set_score`, but it submits `score: 1` against the factory default `points_possible=1` — numerically it happens to look valid either way, so it never exposed the bug.
- `test_put_result_set_score_fail_multiple_times` does submit a fractional `score: 0.8`, but mocks `submissions.views.xqueue.set_score` directly, so the real `ScoreSerializer` validation path never runs.

This PR adds `test_put_result_scales_fractional_score_to_points_earned`, which uses a real (unmocked) `set_score()` call with `points_possible=10` and a fractional grader score, and asserts the resulting `Score.points_earned` is the correctly scaled integer. Confirmed this test reproduces the exact production traceback (`SubmissionInternalError: {'points_earned': [ErrorDetail(string='A valid integer is required.', code='invalid')]}`) when run against the pre-fix code.

## Testing

```
$ pytest submissions/tests/test_viewsets.py -q
26 passed
```
Also ran `pylint`, `isort --check-only`, and `pycodestyle` on the changed files — clean.

## Impact / motivation

Found via production impact on an MIT-operated Open edX instance: `xqueue-watcher` submissions for an exam with a problem worth more than 1 point were failing 100% of the time, blocking grading entirely.

## Release

Bumps `submissions/__init__.py` version 4.0.1 → 4.0.2 so this can be released as-is once merged, following the same convention as #352.